### PR TITLE
Revised sizeOfBuffer check in clblm_ODLAY.f90 to avoid precision issue

### DIFF
--- a/src/clblm_src/clblm_ODLAY.f90
+++ b/src/clblm_src/clblm_ODLAY.f90
@@ -228,6 +228,8 @@ integer, SAVE :: JRAD
       real                 :: DVnorm
       integer              :: numNarrowLines
       real                 :: narrowWidth
+! MJI - add small epsilon value for sizeOfBuffer check
+      real, parameter      :: v2eps = 1.e-7
 
 
 
@@ -461,7 +463,8 @@ endif
       ! AND THE LAST NPTS=MPTS VALUES ENDING AT NLIM OF THE R1 ARRAY
       !
       sizeOfBuffer = ceiling( (V2-V1)/DV  + 1. )
-      if (V1+real(sizeOfBuffer-1)*DV <=V2) sizeOfBuffer=sizeOfBuffer+1  ! "+1" to ensure the last point is beyond V2
+! MJI - Revised sizeOfBuffer check by adding v2eps to allow check to pass and add extra point beyond numerical precision
+      if (V1+real(sizeOfBuffer-1)*DV <=V2+v2eps) sizeOfBuffer=sizeOfBuffer+1  ! "+1" to ensure the last point is beyond V2
 
       allocate( r1BuffNorm( sizeOfBuffer ), STAT=iStat )
       !if (NLTE==.TRUE.) allocate( rr1BuffNorm( sizeOfBuffer ), STAT=iStat )


### PR DESCRIPTION
The pull request includes a change to clblm_ODLAY.f90 to revise the sizeOfBuffer check to allow the check to pass when needed to add an extra element to the buffer size. The check was not passing in some circumstances when the derived value being checked against V2 was very slightly larger than V2 at the level of numerical precision. The offered solution adds a small epsilon value (1.e-07) to V2 at the time of the check to avoid the precision issue. 